### PR TITLE
QcMetaData: Fix Compile

### DIFF
--- a/mm-core/inc/QCMetaData.h
+++ b/mm-core/inc/QCMetaData.h
@@ -66,7 +66,7 @@ enum {
     kKeySmoothStreaming      = 'ESmS',  //bool (int32_t)
     kKeyHFR                  = 'hfr ',  // int32_t
 
-    kKeySampleBits        = 'sbit', // int32_t (audio sample bit-width)
+    //kKeySampleBits        = 'sbit', // int32_t (audio sample bit-width)
     kKeyMinBlkSize        = 'mibs', //int32_t
     kKeyMaxBlkSize        = 'mabs', //int32_t
     kKeyMinFrmSize        = 'mifs', //int32_t

--- a/mm-video/vidc/vdec/Android.mk
+++ b/mm-video/vidc/vdec/Android.mk
@@ -40,6 +40,7 @@ libOmxVdec-def += -D_COPPER_
 endif
 ifeq ($(TARGET_BOARD_PLATFORM),msm7x30)
 libOmxVdec-def += -DMAX_RES_720P
+libOmxVdec-def += -DNO_IOMMU
 endif
 
 libOmxVdec-def += -D_ANDROID_ICS_

--- a/mm-video/vidc/vdec/src/omx_vdec.cpp
+++ b/mm-video/vidc/vdec/src/omx_vdec.cpp
@@ -115,11 +115,7 @@ char ouputextradatafilename [] = "/data/extradata";
 
 #ifdef USE_ION
     #define MEM_DEVICE "/dev/ion"
-    #ifdef MAX_RES_720P
-    #define MEM_HEAP_ID ION_CAMERA_HEAP_ID
-    #else
     #define MEM_HEAP_ID ION_CP_MM_HEAP_ID
-    #endif
 #elif MAX_RES_720P
 #define MEM_DEVICE "/dev/pmem_adsp"
 #elif MAX_RES_1080P_EBI
@@ -3077,7 +3073,7 @@ OMX_ERRORTYPE  omx_vdec::get_parameter(OMX_IN OMX_HANDLETYPE     hComp,
             if(nativeBuffersUsage->nPortIndex == OMX_CORE_OUTPUT_PORT_INDEX) {
 #ifdef USE_ION
 #if defined (MAX_RES_720P)
-                nativeBuffersUsage->nUsage = (GRALLOC_USAGE_PRIVATE_ADSP_HEAP | GRALLOC_USAGE_PRIVATE_UNCACHED);
+                nativeBuffersUsage->nUsage = (GRALLOC_USAGE_PRIVATE_MM_HEAP | GRALLOC_USAGE_PRIVATE_UNCACHED);
                 DEBUG_PRINT_HIGH("ION:720P: nUsage 0x%x",nativeBuffersUsage->nUsage);
 #else
                 if(secure_mode) {
@@ -3095,7 +3091,7 @@ OMX_ERRORTYPE  omx_vdec::get_parameter(OMX_IN OMX_HANDLETYPE     hComp,
 #endif //(MAX_RES_720P)
 #else
 #if defined (MAX_RES_720P) ||  defined (MAX_RES_1080P_EBI)
-                nativeBuffersUsage->nUsage = (GRALLOC_USAGE_PRIVATE_ADSP_HEAP | GRALLOC_USAGE_PRIVATE_UNCACHED);
+                nativeBuffersUsage->nUsage = (GRALLOC_USAGE_PRIVATE_MM_HEAP | GRALLOC_USAGE_PRIVATE_UNCACHED);
 #elif MAX_RES_1080P
                 nativeBuffersUsage->nUsage = (GRALLOC_USAGE_PRIVATE_SMI_HEAP | GRALLOC_USAGE_PRIVATE_UNCACHED);
 #endif

--- a/mm-video/vidc/venc/Android.mk
+++ b/mm-video/vidc/venc/Android.mk
@@ -35,6 +35,7 @@ libmm-venc-def += -DBADGER
 endif
 ifeq ($(TARGET_BOARD_PLATFORM),msm7x30)
 libmm-venc-def += -DMAX_RES_720P
+libmm-venc-def += -DNO_IOMMU
 endif
 ifeq ($(TARGET_USES_ION),true)
 libmm-venc-def += -DUSE_ION

--- a/mm-video/vidc/venc/inc/omx_video_base.h
+++ b/mm-video/vidc/venc/inc/omx_video_base.h
@@ -83,11 +83,7 @@ public:
 
 #ifdef USE_ION
     static const char* MEM_DEVICE = "/dev/ion";
-    #ifdef MAX_RES_720P
-    #define MEM_HEAP_ID ION_CAMERA_HEAP_ID
-    #else
     #define MEM_HEAP_ID ION_CP_MM_HEAP_ID
-    #endif
 #elif MAX_RES_720P
 static const char* MEM_DEVICE = "/dev/pmem_adsp";
 #elif MAX_RES_1080P_EBI


### PR DESCRIPTION
With latest CM sync i was getting error duplicate define between this and frameworks\av. After commenting this line rom compiles fine.
